### PR TITLE
Point to correct certificate for NPM

### DIFF
--- a/src/cs-openresty-bouncer/build.sh
+++ b/src/cs-openresty-bouncer/build.sh
@@ -35,6 +35,6 @@ mkdir /tmp/crowdsec-openresty-bouncer
 curl -# -L "${CROWDSEC_OPENRESTY_BOUNCER_URL}" | tar xz --strip 1 -C /tmp/crowdsec-openresty-bouncer
 log "Deploy Crowdsec Openresty Bouncer..."
 cd /tmp/crowdsec-openresty-bouncer
-bash ./install.sh --NGINX_CONF_DIR=${ROOTFS}/etc/nginx/conf.d --LIB_PATH=${ROOTFS}/var/lib/nginx/lualib --CONFIG_PATH=${ROOTFS}/defaults/crowdsec/ --DATA_PATH=${ROOTFS}/defaults/crowdsec/ --SSL_CERTS_PATH=/etc/ssl/certs/ca-cert-GTS_Root_R1.pem --docker
+bash ./install.sh --NGINX_CONF_DIR=${ROOTFS}/etc/nginx/conf.d --LIB_PATH=${ROOTFS}/var/lib/nginx/lualib --CONFIG_PATH=${ROOTFS}/defaults/crowdsec/ --DATA_PATH=${ROOTFS}/defaults/crowdsec/ --SSL_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt --docker
 sed -i 's|/tmp/crowdsec-openresty-bouncer-install||g' ${ROOTFS}/etc/nginx/conf.d/crowdsec_openresty.conf
 sed -i 's|ENABLED=.*|ENABLED=false|' ${ROOTFS}/defaults/crowdsec/crowdsec-openresty-bouncer.conf 


### PR DESCRIPTION
Current build fails to reach out to LAPI at a remote location if LAPI is accessible through a URL eg. https://crowdsec.local.example.com. It works only if LAPI is reached through its IP with 8080 port exposed, thereby preferring a relative less secure implementation. This will solve https://github.com/LePresidente/docker-nginx-proxy-manager/issues/19